### PR TITLE
fix: swiftlint 수정

### DIFF
--- a/Moa/.swiftlint.yml
+++ b/Moa/.swiftlint.yml
@@ -75,6 +75,8 @@ identifier_name:
     - x
     - y
     - z
+  allowed_symbols:
+    - _
 
 nesting:
   type_level:


### PR DESCRIPTION
swiftlint에서 identifier name에서 _가 빠져있어서 typo 에서 에러 발생

### 📌 Summary
<!-- 이 PR에서 무엇을 해결했는지 간단히 설명해주세요 -->
- swiftlint에서 _가 identifier name 규칙에 빠져있어서 typo 변수 이름 에러 발생

---

### 🛠️ Changes
<!-- 주요 변경 사항을 bullet point로 작성해주세요 -->

- swiftlint 내 identifier name 에 _ 기호 허용 추가

---

