### PR TITLE
카카오로 로그인

### DIFF
--- a/Moa/Moa.xcodeproj/project.pbxproj
+++ b/Moa/Moa.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		8D1A506A2F38EAB6002A78C4 /* KakaoSDK in Frameworks */ = {isa = PBXBuildFile; productRef = 8D1A50692F38EAB6002A78C4 /* KakaoSDK */; };
 		8D3FA1802F23DF9A00EAE229 /* SnapKit in Frameworks */ = {isa = PBXBuildFile; productRef = 8D3FA17F2F23DF9A00EAE229 /* SnapKit */; };
+		8DFB12342F3A1D6600F0334A /* FirebaseAnalytics in Frameworks */ = {isa = PBXBuildFile; productRef = 8DFB12332F3A1D6600F0334A /* FirebaseAnalytics */; };
 		CD2DE8192F279DA800CC8D17 /* CombineMoya in Frameworks */ = {isa = PBXBuildFile; productRef = CD2DE8182F279DA800CC8D17 /* CombineMoya */; };
 		CD2DE81B2F279DA800CC8D17 /* Moya in Frameworks */ = {isa = PBXBuildFile; productRef = CD2DE81A2F279DA800CC8D17 /* Moya */; };
 		CDCF8BDD2F24B15A003F8ED7 /* .swiftlint.yml in Resources */ = {isa = PBXBuildFile; fileRef = CDCF8BDC2F24B15A003F8ED7 /* .swiftlint.yml */; };
@@ -48,6 +49,7 @@
 				CD2DE8192F279DA800CC8D17 /* CombineMoya in Frameworks */,
 				8D1A506A2F38EAB6002A78C4 /* KakaoSDK in Frameworks */,
 				8D3FA1802F23DF9A00EAE229 /* SnapKit in Frameworks */,
+				8DFB12342F3A1D6600F0334A /* FirebaseAnalytics in Frameworks */,
 				CD2DE81B2F279DA800CC8D17 /* Moya in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -97,6 +99,7 @@
 				CD2DE8182F279DA800CC8D17 /* CombineMoya */,
 				CD2DE81A2F279DA800CC8D17 /* Moya */,
 				8D1A50692F38EAB6002A78C4 /* KakaoSDK */,
+				8DFB12332F3A1D6600F0334A /* FirebaseAnalytics */,
 			);
 			productName = Moa;
 			productReference = 8DAC508D2F20FF7100FAA818 /* Moa.app */;
@@ -130,6 +133,7 @@
 				8D3FA17E2F23DF9A00EAE229 /* XCRemoteSwiftPackageReference "SnapKit" */,
 				CD2DE8172F279DA800CC8D17 /* XCRemoteSwiftPackageReference "Moya" */,
 				8D1A50682F38EAB6002A78C4 /* XCRemoteSwiftPackageReference "kakao-ios-sdk" */,
+				8DFB12322F3A1D6600F0334A /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */,
 			);
 			preferredProjectObjectVersion = 77;
 			productRefGroup = 8DAC508E2F20FF7100FAA818 /* Products */;
@@ -191,6 +195,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_ENTITLEMENTS = Moa/Moa.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
@@ -208,7 +213,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = kr.co.nexters.moa;
+				PRODUCT_BUNDLE_IDENTIFIER = kr.co.nexters.ios.moa;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				STRING_CATALOG_GENERATE_SYMBOLS = YES;
@@ -232,6 +237,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_ENTITLEMENTS = Moa/Moa.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
@@ -249,7 +255,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = kr.co.nexters.moa;
+				PRODUCT_BUNDLE_IDENTIFIER = kr.co.nexters.ios.moa;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				STRING_CATALOG_GENERATE_SYMBOLS = YES;
@@ -431,6 +437,14 @@
 				minimumVersion = 5.7.1;
 			};
 		};
+		8DFB12322F3A1D6600F0334A /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/firebase/firebase-ios-sdk";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 12.9.0;
+			};
+		};
 		CD2DE8172F279DA800CC8D17 /* XCRemoteSwiftPackageReference "Moya" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/Moya/Moya.git";
@@ -451,6 +465,11 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 8D3FA17E2F23DF9A00EAE229 /* XCRemoteSwiftPackageReference "SnapKit" */;
 			productName = SnapKit;
+		};
+		8DFB12332F3A1D6600F0334A /* FirebaseAnalytics */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 8DFB12322F3A1D6600F0334A /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
+			productName = FirebaseAnalytics;
 		};
 		CD2DE8182F279DA800CC8D17 /* CombineMoya */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/Moa/Moa.xcodeproj/project.pbxproj
+++ b/Moa/Moa.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		8D1A506A2F38EAB6002A78C4 /* KakaoSDK in Frameworks */ = {isa = PBXBuildFile; productRef = 8D1A50692F38EAB6002A78C4 /* KakaoSDK */; };
 		8D3FA1802F23DF9A00EAE229 /* SnapKit in Frameworks */ = {isa = PBXBuildFile; productRef = 8D3FA17F2F23DF9A00EAE229 /* SnapKit */; };
 		CD2DE8192F279DA800CC8D17 /* CombineMoya in Frameworks */ = {isa = PBXBuildFile; productRef = CD2DE8182F279DA800CC8D17 /* CombineMoya */; };
 		CD2DE81B2F279DA800CC8D17 /* Moya in Frameworks */ = {isa = PBXBuildFile; productRef = CD2DE81A2F279DA800CC8D17 /* Moya */; };
@@ -45,6 +46,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				CD2DE8192F279DA800CC8D17 /* CombineMoya in Frameworks */,
+				8D1A506A2F38EAB6002A78C4 /* KakaoSDK in Frameworks */,
 				8D3FA1802F23DF9A00EAE229 /* SnapKit in Frameworks */,
 				CD2DE81B2F279DA800CC8D17 /* Moya in Frameworks */,
 			);
@@ -94,6 +96,7 @@
 				8D3FA17F2F23DF9A00EAE229 /* SnapKit */,
 				CD2DE8182F279DA800CC8D17 /* CombineMoya */,
 				CD2DE81A2F279DA800CC8D17 /* Moya */,
+				8D1A50692F38EAB6002A78C4 /* KakaoSDK */,
 			);
 			productName = Moa;
 			productReference = 8DAC508D2F20FF7100FAA818 /* Moa.app */;
@@ -126,6 +129,7 @@
 			packageReferences = (
 				8D3FA17E2F23DF9A00EAE229 /* XCRemoteSwiftPackageReference "SnapKit" */,
 				CD2DE8172F279DA800CC8D17 /* XCRemoteSwiftPackageReference "Moya" */,
+				8D1A50682F38EAB6002A78C4 /* XCRemoteSwiftPackageReference "kakao-ios-sdk" */,
 			);
 			preferredProjectObjectVersion = 77;
 			productRefGroup = 8DAC508E2F20FF7100FAA818 /* Products */;
@@ -182,12 +186,15 @@
 /* Begin XCBuildConfiguration section */
 		8DAC50A12F20FF7300FAA818 /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReferenceAnchor = 8DAC508F2F20FF7100FAA818 /* Moa */;
+			baseConfigurationReferenceRelativePath = Config/Secrets.xcconfig;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = 3PT6ZHQG99;
+				DEVELOPMENT_TEAM = 5QS2KL98Q7;
 				ENABLE_USER_SCRIPT_SANDBOXING = NO;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = Moa/Info.plist;
@@ -201,8 +208,9 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = kr.co.nexters.moa.ios;
+				PRODUCT_BUNDLE_IDENTIFIER = kr.co.nexters.moa;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
 				STRING_CATALOG_GENERATE_SYMBOLS = YES;
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;
@@ -219,12 +227,15 @@
 		};
 		8DAC50A22F20FF7300FAA818 /* Release */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReferenceAnchor = 8DAC508F2F20FF7100FAA818 /* Moa */;
+			baseConfigurationReferenceRelativePath = Config/Secrets.xcconfig;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = 3PT6ZHQG99;
+				DEVELOPMENT_TEAM = 5QS2KL98Q7;
 				ENABLE_USER_SCRIPT_SANDBOXING = NO;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = Moa/Info.plist;
@@ -238,8 +249,9 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = kr.co.nexters.moa.ios;
+				PRODUCT_BUNDLE_IDENTIFIER = kr.co.nexters.moa;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
 				STRING_CATALOG_GENERATE_SYMBOLS = YES;
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;
@@ -256,6 +268,8 @@
 		};
 		8DAC50A32F20FF7300FAA818 /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReferenceAnchor = 8DAC508F2F20FF7100FAA818 /* Moa */;
+			baseConfigurationReferenceRelativePath = Config/Secrets.xcconfig;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
@@ -320,6 +334,8 @@
 		};
 		8DAC50A42F20FF7300FAA818 /* Release */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReferenceAnchor = 8DAC508F2F20FF7100FAA818 /* Moa */;
+			baseConfigurationReferenceRelativePath = Config/Secrets.xcconfig;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
@@ -399,6 +415,14 @@
 /* End XCConfigurationList section */
 
 /* Begin XCRemoteSwiftPackageReference section */
+		8D1A50682F38EAB6002A78C4 /* XCRemoteSwiftPackageReference "kakao-ios-sdk" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/kakao/kakao-ios-sdk";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 2.27.2;
+			};
+		};
 		8D3FA17E2F23DF9A00EAE229 /* XCRemoteSwiftPackageReference "SnapKit" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/SnapKit/SnapKit.git";
@@ -418,6 +442,11 @@
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
+		8D1A50692F38EAB6002A78C4 /* KakaoSDK */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 8D1A50682F38EAB6002A78C4 /* XCRemoteSwiftPackageReference "kakao-ios-sdk" */;
+			productName = KakaoSDK;
+		};
 		8D3FA17F2F23DF9A00EAE229 /* SnapKit */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = 8D3FA17E2F23DF9A00EAE229 /* XCRemoteSwiftPackageReference "SnapKit" */;

--- a/Moa/Moa.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Moa/Moa.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,6 +1,15 @@
 {
-  "originHash" : "87068f57be3f425d2ac9aa327ba2a67ba62dd61fcd4e77ebeabfec6b6c84b696",
+  "originHash" : "acc2835dc8a1994c80cdedff0230c76417453d5858e3e47280f4dc43bac37a6d",
   "pins" : [
+    {
+      "identity" : "abseil-cpp-binary",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/abseil-cpp-binary.git",
+      "state" : {
+        "revision" : "bbe8b69694d7873315fd3a4ad41efe043e1c07c5",
+        "version" : "1.2024072200.0"
+      }
+    },
     {
       "identity" : "alamofire",
       "kind" : "remoteSourceControl",
@@ -8,6 +17,87 @@
       "state" : {
         "revision" : "7be73f6c2b5cd90e40798b06ebd5da8f9f79cf88",
         "version" : "5.11.0"
+      }
+    },
+    {
+      "identity" : "app-check",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/app-check.git",
+      "state" : {
+        "revision" : "61b85103a1aeed8218f17c794687781505fbbef5",
+        "version" : "11.2.0"
+      }
+    },
+    {
+      "identity" : "firebase-ios-sdk",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/firebase/firebase-ios-sdk",
+      "state" : {
+        "revision" : "9b3aed4fa6226125305b82d4d86c715bef250785",
+        "version" : "12.9.0"
+      }
+    },
+    {
+      "identity" : "google-ads-on-device-conversion-ios-sdk",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/googleads/google-ads-on-device-conversion-ios-sdk",
+      "state" : {
+        "revision" : "35b601a60fbbea2de3ea461f604deaaa4d8bbd0c",
+        "version" : "3.2.0"
+      }
+    },
+    {
+      "identity" : "googleappmeasurement",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/GoogleAppMeasurement.git",
+      "state" : {
+        "revision" : "2ffd220823f3716904733162e9ae685545c276d1",
+        "version" : "12.8.0"
+      }
+    },
+    {
+      "identity" : "googledatatransport",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/GoogleDataTransport.git",
+      "state" : {
+        "revision" : "617af071af9aa1d6a091d59a202910ac482128f9",
+        "version" : "10.1.0"
+      }
+    },
+    {
+      "identity" : "googleutilities",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/GoogleUtilities.git",
+      "state" : {
+        "revision" : "60da361632d0de02786f709bdc0c4df340f7613e",
+        "version" : "8.1.0"
+      }
+    },
+    {
+      "identity" : "grpc-binary",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/grpc-binary.git",
+      "state" : {
+        "revision" : "75b31c842f664a0f46a2e590a570e370249fd8f6",
+        "version" : "1.69.1"
+      }
+    },
+    {
+      "identity" : "gtm-session-fetcher",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/gtm-session-fetcher.git",
+      "state" : {
+        "revision" : "fb7f2740b1570d2f7599c6bb9531bf4fad6974b7",
+        "version" : "5.0.0"
+      }
+    },
+    {
+      "identity" : "interop-ios-for-google-sdks",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/interop-ios-for-google-sdks.git",
+      "state" : {
+        "revision" : "040d087ac2267d2ddd4cca36c757d1c6a05fdbfe",
+        "version" : "101.0.0"
       }
     },
     {
@@ -20,12 +110,39 @@
       }
     },
     {
+      "identity" : "leveldb",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/firebase/leveldb.git",
+      "state" : {
+        "revision" : "a0bc79961d7be727d258d33d5a6b2f1023270ba1",
+        "version" : "1.22.5"
+      }
+    },
+    {
       "identity" : "moya",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/Moya/Moya.git",
       "state" : {
         "revision" : "c263811c1f3dbf002be9bd83107f7cdc38992b26",
         "version" : "15.0.3"
+      }
+    },
+    {
+      "identity" : "nanopb",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/firebase/nanopb.git",
+      "state" : {
+        "revision" : "b7e1104502eca3a213b46303391ca4d3bc8ddec1",
+        "version" : "2.30910.0"
+      }
+    },
+    {
+      "identity" : "promises",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/promises.git",
+      "state" : {
+        "revision" : "540318ecedd63d883069ae7f1ed811a2df00b6ac",
+        "version" : "2.4.0"
       }
     },
     {

--- a/Moa/Moa.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Moa/Moa.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "c357713a400e929f3e6e12043ba59f7765e58cde189dbcbd792449cd00577530",
+  "originHash" : "87068f57be3f425d2ac9aa327ba2a67ba62dd61fcd4e77ebeabfec6b6c84b696",
   "pins" : [
     {
       "identity" : "alamofire",
@@ -8,6 +8,15 @@
       "state" : {
         "revision" : "7be73f6c2b5cd90e40798b06ebd5da8f9f79cf88",
         "version" : "5.11.0"
+      }
+    },
+    {
+      "identity" : "kakao-ios-sdk",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/kakao/kakao-ios-sdk",
+      "state" : {
+        "revision" : "5978979157a5a0521c9c56fd0156aec794caa21c",
+        "version" : "2.27.2"
       }
     },
     {

--- a/Moa/Moa/App/AppDelegate.swift
+++ b/Moa/Moa/App/AppDelegate.swift
@@ -6,12 +6,15 @@
 //
 
 import UIKit
+import KakaoSDKCommon
 
 @main
 class AppDelegate: UIResponder, UIApplicationDelegate {
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
-        // Override point for customization after application launch.
+        if let kakaoNativeAppKey = Bundle.main.object(forInfoDictionaryKey: "KAKAO_NATIVE_APP_KEY") as? String {
+            KakaoSDK.initSDK(appKey: kakaoNativeAppKey)
+        }
         return true
     }
 

--- a/Moa/Moa/App/AppDelegate.swift
+++ b/Moa/Moa/App/AppDelegate.swift
@@ -7,14 +7,31 @@
 
 import UIKit
 import KakaoSDKCommon
+import FirebaseCore
 
 @main
 class AppDelegate: UIResponder, UIApplicationDelegate {
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
+        
+        // 카카오 네이티브 앱 키 설정
         if let kakaoNativeAppKey = Bundle.main.object(forInfoDictionaryKey: "KAKAO_NATIVE_APP_KEY") as? String {
             KakaoSDK.initSDK(appKey: kakaoNativeAppKey)
         }
+        
+        // Firebase 초기화
+        FirebaseApp.configure()
+        
+        // 알림 권한 요청
+        UNUserNotificationCenter.current().requestAuthorization(options: [.alert, .badge, .sound]) { granted, error in
+            if let error { print("Notification auth error:", error) }
+            print("Notification granted:", granted)
+            
+            DispatchQueue.main.async {
+                UIApplication.shared.registerForRemoteNotifications()
+            }
+        }
+        
         return true
     }
 
@@ -32,5 +49,13 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         // Use this method to release any resources that were specific to the discarded scenes, as they will not return.
     }
 
-
+    func application(_ application: UIApplication, didRegisterForRemoteNotificationsWithDeviceToken deviceToken: Data) {
+        let tokenString = deviceToken.map { String(format: "%02x", $0) }.joined()
+        UserDefaults.standard.set(tokenString, forKey: "apnsDeviceToken")
+        print("APNs Device Token:", tokenString)
+    }
+    
+    func application(_ application: UIApplication, didFailToRegisterForRemoteNotificationsWithError error: Error) {
+        print("APNs 등록 실패:", error)
+    }
 }

--- a/Moa/Moa/App/AppRouter.swift
+++ b/Moa/Moa/App/AppRouter.swift
@@ -59,7 +59,7 @@ private extension AppRouter {
     }
     
     func makeLogin() -> UIViewController {
-        let vm = LoginViewModel()
+        let vm = LoginViewModel(authUsecase: container.authUseCase)
         return LoginViewController(viewModel: vm, router: self)
     }
     

--- a/Moa/Moa/App/SceneDelegate.swift
+++ b/Moa/Moa/App/SceneDelegate.swift
@@ -6,6 +6,7 @@
 //
 
 import UIKit
+import KakaoSDKAuth
 
 class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     
@@ -33,6 +34,14 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         window.makeKeyAndVisible()
         self.window = window
         router.start()
+    }
+    
+    func scene(_ scene: UIScene, openURLContexts URLContexts: Set<UIOpenURLContext>) {
+        if let url = URLContexts.first?.url {
+            if AuthApi.isKakaoTalkLoginUrl(url) {
+                _ = AuthController.handleOpenUrl(url: url)
+            }
+        }
     }
     
     func sceneDidDisconnect(_ scene: UIScene) {

--- a/Moa/Moa/Config/SecretsTemplate.xcconfig
+++ b/Moa/Moa/Config/SecretsTemplate.xcconfig
@@ -1,0 +1,10 @@
+//
+//  SecretsTemplate.xcconfig
+//  Moa
+//
+//  Created by mirim on 2/9/26.
+//
+
+// ⚠️ REQUIRED: 이 파일을 Config/Secrets.xcconfig 로 복사한 뒤 __REPLACE_ME__ 를 실제 값으로 교체
+
+KAKAO_NATIVE_APP_KEY = __REPLACE_ME__

--- a/Moa/Moa/Core/DI/AppContainer.swift
+++ b/Moa/Moa/Core/DI/AppContainer.swift
@@ -36,6 +36,12 @@ final class AppContainer {
     }()
 
     // MARK: - Repository
+    lazy var authRepository: AuthRepository = {
+        AuthRepositoryImpl(apiClient: apiClient)
+    }()
 
     // MARK: - UseCase
+    lazy var authUseCase: AuthUsecase = {
+        AuthUsecase(repository: authRepository)
+    }()
 }

--- a/Moa/Moa/Core/Network/APIClient.swift
+++ b/Moa/Moa/Core/Network/APIClient.swift
@@ -10,5 +10,5 @@ import Moya
 
 /// 네트워크 요청에 대한 추상화 인터페이스
 protocol APIClient {
-    func request<T: Decodable>(_ target: TargetType) -> AnyPublisher<T, APIError>
+    func request<T: Decodable>(_ target: TargetType) async throws -> T
 }

--- a/Moa/Moa/Core/Network/APIError.swift
+++ b/Moa/Moa/Core/Network/APIError.swift
@@ -10,6 +10,12 @@ import Moya
 enum APIError: Error {
     case network(MoyaError)       // Moya 내부 에러 처리
     case decoding(Error)          // Decoding Failure
-    case server(Int)              // HTTP 상태 코드 처리
+    case httpStatus(Int)          // HTTP 상태 코드 처리
+    case server(code: String, message: String, fieldErrors: [FieldError]?) // 서버 표준 에러
     case unknown                  // unknown
+}
+
+struct FieldError: Decodable {
+    let field: String
+    let message: String
 }

--- a/Moa/Moa/Core/Network/MoyaAPIClient.swift
+++ b/Moa/Moa/Core/Network/MoyaAPIClient.swift
@@ -18,19 +18,58 @@ final class MoyaAPIClient: APIClient {
         self.provider = provider
     }
 
-    func request<T: Decodable>(_ target: TargetType) -> AnyPublisher<T, APIError> {
-        provider.requestPublisher(MultiTarget(target))
-            .mapError { APIError.network($0) }
-            .tryMap { response in
-                guard (200..<300).contains(response.statusCode) else {
-                    throw APIError.server(response.statusCode)
+    func request<T: Decodable>(_ target: TargetType) async throws -> T {
+        try await withCheckedThrowingContinuation { continuation in
+            provider.request(MultiTarget(target)) { result in
+                switch result {
+                case let .success(response):
+                    do {
+                        // HTTP 상태 코드 체크
+                        guard (200..<300).contains(response.statusCode) else {
+                            // 4xx, 5xx 에러 응답 파싱 시도
+                            if let errorResponse = try? JSONDecoder().decode(
+                                ErrorResponse.self,
+                                from: response.data
+                            ) {
+                                throw APIError.server(
+                                    code: errorResponse.code,
+                                    message: errorResponse.message,
+                                    fieldErrors: errorResponse.fieldErrors
+                                )
+                            }
+                            throw APIError.httpStatus(response.statusCode)
+                        }
+                        
+                        // 정상 응답 파싱
+                        let decoded = try JSONDecoder().decode(
+                            BaseResponse<T>.self,
+                            from: response.data
+                        )
+                        
+                        continuation.resume(returning: decoded.content)
+                    } catch {
+                        if let apiError = error as? APIError {
+                            continuation.resume(throwing: apiError)
+                        } else {
+                            continuation.resume(throwing: error)
+                        }
+                    }
+                    
+                case let .failure(error):
+                    if let errorData = error.response?.data,
+                       let serverError = try? JSONDecoder().decode(ErrorResponse.self, from: errorData) {
+                        continuation.resume(
+                            throwing: APIError.server(
+                                code: serverError.code,
+                                message: serverError.message,
+                                fieldErrors: serverError.fieldErrors
+                            )
+                        )
+                    } else {
+                        continuation.resume(throwing: APIError.network(error))
+                    }
                 }
-                return response.data
             }
-            .decode(type: T.self, decoder: JSONDecoder())
-            .mapError {
-                ($0 as? APIError) ?? APIError.decoding($0)
-            }
-            .eraseToAnyPublisher()
+        }
     }
 }

--- a/Moa/Moa/Core/Network/Target/AuthAPI.swift
+++ b/Moa/Moa/Core/Network/Target/AuthAPI.swift
@@ -10,46 +10,53 @@ import Moya
 import Alamofire
 
 enum AuthAPI {
-    case checkLogin
+    case kakaoAuth(SocialLoginRequest)
+    case appleAuth(SocialLoginRequest)
 }
 
 extension AuthAPI: TargetType {
 
-    // MARK: - Base URL
     var baseURL: URL {
-        URL(string: "https://test.com")!        // TODO: URL 교체 필요
+        URL(string: "http://139.150.10.57:8080")!
     }
 
-    // MARK: - Path
     var path: String {
         switch self {
-        case .checkLogin:
-            return "/auth/status"               // TODO: URL 교체 필요
+        case .kakaoAuth:
+            return "/api/v1/auth/kakao"
+            
+        case .appleAuth:
+            return "/api/v1/auth/apple"
         }
     }
 
-    // MARK: - Method
     var method: Moya.Method {
         switch self {
-        case .checkLogin:
-            return .get
+        case .kakaoAuth:
+            return .post
+            
+        case .appleAuth:
+            return .post
         }
     }
 
-    // MARK: - Task
     var task: Moya.Task {
-        .requestPlain
+        switch self {
+        case let .kakaoAuth(body):
+            return .requestJSONEncodable(body)
+            
+        case let .appleAuth(body):
+            return .requestJSONEncodable(body)
+        }
     }
 
-    // MARK: - Headers
     var headers: [String: String]? {
         nil
     }
 
-    // MARK: - Sample Data (Stub / Test)
     var sampleData: Data {
         switch self {
-        case .checkLogin:
+        default:
             return """
             {
               "isLoggedIn": true

--- a/Moa/Moa/Data/Remote/DTO/Auth/SocialLoginRequest.swift
+++ b/Moa/Moa/Data/Remote/DTO/Auth/SocialLoginRequest.swift
@@ -1,0 +1,13 @@
+//
+//  SocialLoginRequest.swift
+//  Moa
+//
+//  Created by mirim on 2/10/26.
+//
+
+import Foundation
+
+struct SocialLoginRequest: Encodable {
+    let idToken: String
+    let fcmDeviceToken: String
+}

--- a/Moa/Moa/Data/Remote/DTO/Auth/SocialLoginResponse.swift
+++ b/Moa/Moa/Data/Remote/DTO/Auth/SocialLoginResponse.swift
@@ -1,0 +1,16 @@
+//
+//  SocialLoginResponse.swift
+//  Moa
+//
+//  Created by mirim on 2/11/26.
+//
+
+import Foundation
+
+struct SocialLoginResponse: Decodable {
+    let accessToken: String
+    
+    func toDomain() -> SocialLoginEntity {
+        .init(accessToken: accessToken)
+    }
+}

--- a/Moa/Moa/Data/Remote/DTO/BaseResponse.swift
+++ b/Moa/Moa/Data/Remote/DTO/BaseResponse.swift
@@ -1,0 +1,15 @@
+//
+//  BaseResponse.swift
+//  Moa
+//
+//  Created by mirim on 2/11/26.
+//
+
+import Foundation
+
+/// 디폴트 성공 리스폰스
+struct BaseResponse<T: Decodable>: Decodable {
+    let code: String
+    let message: String
+    let content: T
+}

--- a/Moa/Moa/Data/Remote/DTO/ErrorResponse.swift
+++ b/Moa/Moa/Data/Remote/DTO/ErrorResponse.swift
@@ -1,0 +1,20 @@
+//
+//  ErrorResponse.swift
+//  Moa
+//
+//  Created by mirim on 2/11/26.
+//
+
+import Foundation
+
+/// 디폴트 에러 리스폰스
+struct ErrorResponse: Decodable {
+    let code: String
+    let message: String
+    let fieldErrors: [FieldError]?
+        
+    enum CodingKeys: String, CodingKey {
+        case code, message
+        case fieldErrors = "content"
+    }
+}

--- a/Moa/Moa/Data/Repository/AuthRepositoryImpl.swift
+++ b/Moa/Moa/Data/Repository/AuthRepositoryImpl.swift
@@ -1,0 +1,27 @@
+//
+//  AuthRepositoryImpl.swift
+//  Moa
+//
+//  Created by mirim on 2/11/26.
+//
+
+import Foundation
+
+final class AuthRepositoryImpl: AuthRepository {
+    private let apiClient: APIClient
+
+    init(apiClient: APIClient) {
+        self.apiClient = apiClient
+    }
+    
+    func loginWithKakaoTalk(
+        idToken: String,
+        fcmDeviceToken: String
+    ) async throws -> SocialLoginEntity {
+        let response: SocialLoginResponse = try await apiClient.request(
+            AuthAPI.kakaoAuth(.init(idToken: idToken, fcmDeviceToken: fcmDeviceToken))
+        )
+        
+        return response.toDomain()
+    }
+}

--- a/Moa/Moa/Domain/Entity/SocialLoginEntity.swift
+++ b/Moa/Moa/Domain/Entity/SocialLoginEntity.swift
@@ -1,0 +1,12 @@
+//
+//  SocialLoginEntity.swift
+//  Moa
+//
+//  Created by mirim on 2/11/26.
+//
+
+import Foundation
+
+struct SocialLoginEntity {
+    let accessToken: String
+}

--- a/Moa/Moa/Domain/Repository/AuthRepository.swift
+++ b/Moa/Moa/Domain/Repository/AuthRepository.swift
@@ -1,0 +1,14 @@
+//
+//  AuthRepository.swift
+//  Moa
+//
+//  Created by mirim on 2/11/26.
+//
+
+import Foundation
+
+protocol AuthRepository {
+    func loginWithKakaoTalk(idToken: String, fcmDeviceToken: String) async throws -> SocialLoginEntity
+    // TODO: loginWithApple
+}
+

--- a/Moa/Moa/Domain/UseCase/AuthUseCase.swift
+++ b/Moa/Moa/Domain/UseCase/AuthUseCase.swift
@@ -1,0 +1,26 @@
+//
+//  AuthUseCase.swift
+//  Moa
+//
+//  Created by mirim on 2/11/26.
+//
+
+import Foundation
+
+final class AuthUsecase {
+    private let repository: AuthRepository
+    
+    init(repository: AuthRepository) {
+        self.repository = repository
+    }
+    
+    func loginWithKakaoTalk(
+        idToken: String,
+        fcmDeviceToken: String
+    ) async throws -> SocialLoginEntity {
+        try await repository.loginWithKakaoTalk(
+            idToken: idToken,
+            fcmDeviceToken: fcmDeviceToken
+        )
+    }
+}

--- a/Moa/Moa/Features/Login/LoginViewController.swift
+++ b/Moa/Moa/Features/Login/LoginViewController.swift
@@ -80,6 +80,8 @@ final class LoginViewController: BaseViewController {
             switch output {
             case .loginSucceed:
                 router?.navigate(to: .onboarding, animated: true)
+            case .loginFailed:
+                break // TODO: 로그인 실패 처리
             }
         }
     }
@@ -90,10 +92,10 @@ final class LoginViewController: BaseViewController {
     }
     
     @objc private func didTapKakao() {
-        viewModel.didTapLogin()
+        viewModel.didTapLoginWithKakaoTalk()
     }
     
     @objc private func didTapApple() {
-        viewModel.didTapLogin()
+        viewModel.didTapLoginWithApple()
     }
 }

--- a/Moa/Moa/Features/Login/LoginViewModel.swift
+++ b/Moa/Moa/Features/Login/LoginViewModel.swift
@@ -7,6 +7,8 @@
 
 import Foundation
 import Combine
+import KakaoSDKUser
+import KakaoSDKAuth
 
 enum LoginOutput {
     case loginSucceed
@@ -14,7 +16,15 @@ enum LoginOutput {
 
 final class LoginViewModel: BaseViewModel<LoginOutput> {
     func didTapLogin() {
-        // TODO: 로그인 로직
-        send(.loginSucceed)
+        if UserApi.isKakaoTalkLoginAvailable() {
+            UserApi.shared.loginWithKakaoTalk { [weak self] oauthToken, error in
+                if let error {
+                    print("카카오로 로그인 실패: \(error)")
+                } else {
+                    print("idToken: \(oauthToken?.idToken)")
+                    self?.send(.loginSucceed)
+                }
+            }
+        }
     }
 }

--- a/Moa/Moa/Features/Login/LoginViewModel.swift
+++ b/Moa/Moa/Features/Login/LoginViewModel.swift
@@ -6,25 +6,62 @@
 //
 
 import Foundation
-import Combine
 import KakaoSDKUser
 import KakaoSDKAuth
 
 enum LoginOutput {
     case loginSucceed
+    case loginFailed
 }
 
 final class LoginViewModel: BaseViewModel<LoginOutput> {
-    func didTapLogin() {
+    private let authUsecase: AuthUsecase
+    
+    init(authUsecase: AuthUsecase) {
+        self.authUsecase = authUsecase
+    }
+    
+    func didTapLoginWithKakaoTalk() {
         if UserApi.isKakaoTalkLoginAvailable() {
             UserApi.shared.loginWithKakaoTalk { [weak self] oauthToken, error in
                 if let error {
                     print("카카오로 로그인 실패: \(error)")
-                } else {
-                    print("idToken: \(oauthToken?.idToken)")
-                    self?.send(.loginSucceed)
+                    return
+                }
+                
+                guard let self,
+                      let idToken = oauthToken?.idToken,
+                      !idToken.isEmpty,
+                      // TODO: 유저디폴트 추상화
+                      let fcmDeviceToken = UserDefaults.standard.string(forKey: "apnsDeviceToken")
+                else {
+                    return
+                }
+                
+                Task { [weak self] in
+                    guard let self = self else { return }
+                    do {
+                        let accessToken = try await self.authUsecase.loginWithKakaoTalk(
+                            idToken: idToken,
+                            fcmDeviceToken: fcmDeviceToken
+                        ).accessToken
+                        
+                        UserDefaults.standard.set(accessToken, forKey: "accessToken")
+                        
+                        await MainActor.run {
+                            self.send(.loginSucceed)
+                        }
+                    } catch {
+                        print("로그인 요청 실패: \(error.localizedDescription)")
+                    }
                 }
             }
+        } else {
+            print("카카오톡 로그인 불가 상태")
         }
+    }
+    
+    func didTapLoginWithApple() {
+        // TODO: Apple로 로그인
     }
 }

--- a/Moa/Moa/GoogleService-Info.plist
+++ b/Moa/Moa/GoogleService-Info.plist
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>API_KEY</key>
+	<string>AIzaSyBKu6vL8Z-k12P_0zrtOt2mmTPgEPOM7Vw</string>
+	<key>GCM_SENDER_ID</key>
+	<string>621775447143</string>
+	<key>PLIST_VERSION</key>
+	<string>1</string>
+	<key>BUNDLE_ID</key>
+	<string>kr.co.nexters.ios.moa</string>
+	<key>PROJECT_ID</key>
+	<string>moamoa-cc333</string>
+	<key>STORAGE_BUCKET</key>
+	<string>moamoa-cc333.firebasestorage.app</string>
+	<key>IS_ADS_ENABLED</key>
+	<false></false>
+	<key>IS_ANALYTICS_ENABLED</key>
+	<false></false>
+	<key>IS_APPINVITE_ENABLED</key>
+	<true></true>
+	<key>IS_GCM_ENABLED</key>
+	<true></true>
+	<key>IS_SIGNIN_ENABLED</key>
+	<true></true>
+	<key>GOOGLE_APP_ID</key>
+	<string>1:621775447143:ios:ab9c46c0a8bf2e63ad20c2</string>
+</dict>
+</plist>

--- a/Moa/Moa/Info.plist
+++ b/Moa/Moa/Info.plist
@@ -2,6 +2,11 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>NSAppTransportSecurity</key>
+	<dict>
+		<key>NSAllowsArbitraryLoads</key>
+		<true/>
+	</dict>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>

--- a/Moa/Moa/Info.plist
+++ b/Moa/Moa/Info.plist
@@ -2,8 +2,24 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>UIDesignRequiresCompatibility</key>
-	<true/>
+	<key>CFBundleURLTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleTypeRole</key>
+			<string>Editor</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>kakao47048a6faee3d9ddf4a5884d7a28c694</string>
+			</array>
+		</dict>
+	</array>
+	<key>KAKAO_NATIVE_APP_KEY</key>
+	<string>$(KAKAO_NATIVE_APP_KEY)</string>
+	<key>LSApplicationQueriesSchemes</key>
+	<array>
+		<string>kakaokompassauth</string>
+		<string>kakaotalk</string>
+	</array>
 	<key>UIAppFonts</key>
 	<array>
 		<string>Pretendard-Bold.otf</string>
@@ -28,5 +44,7 @@
 			</array>
 		</dict>
 	</dict>
+	<key>UIDesignRequiresCompatibility</key>
+	<true/>
 </dict>
 </plist>

--- a/Moa/Moa/Moa.entitlements
+++ b/Moa/Moa/Moa.entitlements
@@ -4,5 +4,9 @@
 <dict>
 	<key>aps-environment</key>
 	<string>development</string>
+	<key>com.apple.developer.applesignin</key>
+	<array>
+		<string>Default</string>
+	</array>
 </dict>
 </plist>

--- a/Moa/Moa/Moa.entitlements
+++ b/Moa/Moa/Moa.entitlements
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>aps-environment</key>
+	<string>development</string>
+</dict>
+</plist>


### PR DESCRIPTION
### 📌 Summary
<!-- 이 PR에서 무엇을 해결했는지 간단히 설명해주세요 -->

- 카카오로 로그인

---

### 🛠️ Changes
<!-- 주요 변경 사항을 bullet point로 작성해주세요 -->

- 카카오로 로그인 구현
  - 내부 서버 호출까지 성공하면 온보딩 연결되도록 하는 부분까지 해뒀습니당
- 네트워크 구조 변경 (combine -> concurrency)
- fcm 연결

---


### 📸 Screenshots / GIF (선택)

https://github.com/user-attachments/assets/671295ba-d6b3-473e-a3f3-1157b5557805


---

### ⚠️ Notes
<!-- 리뷰어가 알아야 할 주의사항, 논의가 필요한 부분 -->

- 카카오로 로그인 붙이면서 네트워크 레이어 구조 잡고, 말한대로 concurrency 사용하도록 수정해뒀어!
- 디테일한 에러처리는 나머지 애플로 로그인이랑 온보딩쪽 붙이면서 해보겠습니당 네트워크 처리 관련해서 변경되었으면 하는 부분 있으면 알려조~
- 아 그리고 capabilities 푸시 추가했더니 갑자기 bundle identifier가 오류나가지고;; 바꿨어ㅠㅠ 카카오 디벨로퍼 쪽에도 업데이트는 해뒀오
- 유저디폴트 지금은 그냥 get/set 해서 쓰는데 시간될때 추상화 한번 해볼게
- 그 AppKey 같은것들 xcconfig에서 관리하려고 해서, 템플릿만 올릴게! 로컬에서 Secrets.xcconfig 만들어서 실제 값은 [노션 문서](https://www.notion.so/teamnexters/Secrets-xcconfig-304235c592d980ef96ebfa1505c0b935?source=copy_link) 보고 넣어주면 될거 같아
