### PR TITLE
fix: 9. 근무 완료 화면 근무시간 조정 바텀시트 안 열림

### DIFF
--- a/Moa/Moa/Core/DesignSystem/Components/KeyValueRowView.swift
+++ b/Moa/Moa/Core/DesignSystem/Components/KeyValueRowView.swift
@@ -135,6 +135,12 @@ final class KeyValueRowView: UIControl {
         valueLabel.setText(value)
         updateAccessibility()
     }
+    
+    func showChevron(_ isShow: Bool) {
+        chevronImageView.isHidden = !isShow
+        updateAccessibility()
+    }
+
 
     private func updateAccessibility() {
         accessibilityLabel = "\(titleLabel.text ?? ""), \(valueLabel.text ?? "")"

--- a/Moa/Moa/Features/Home/Work/WorkMain/Components/WorkMainSummaryView.swift
+++ b/Moa/Moa/Features/Home/Work/WorkMain/Components/WorkMainSummaryView.swift
@@ -140,6 +140,8 @@ final class WorkMainSummaryView: UIView {
         timeRowView.isHidden         = true
         finishedTimeRowView.isHidden = false
         vacationTimeRowView.isHidden = true
+        
+        finishedTimeRowView.showChevron(tappable)
 
         wageRowView.updateValue(formattedWage(dailyWage))
         finishedTimeRowView.updateValue(timeValue)


### PR DESCRIPTION
### 📌 Summary
<!-- 이 PR에서 무엇을 해결했는지 간단히 설명해주세요 -->

- 근무완료 후 Arrow제거


