### PR TITLE
로딩 인디케이터 크기, 홈 공휴일 QA 처리

### DIFF
--- a/Moa/Moa/Features/Home/History/Calendar/Components/Calendar/CalendarDataSource.swift
+++ b/Moa/Moa/Features/Home/History/Calendar/Components/Calendar/CalendarDataSource.swift
@@ -63,7 +63,6 @@ final class CalendarDataSource {
     }
     
     @discardableResult func moveToNextMonth() -> Date {
-        guard canMoveToNextMonth() else { return currentDate }
         currentDate = calendar.date(byAdding: .month, value: 1, to: currentDate) ?? currentDate
         return currentDate
     }
@@ -96,13 +95,7 @@ final class CalendarDataSource {
         return formatter.string(from: date)
     }
     
-    func canMoveToNextMonth() -> Bool {
-        let now = Date()
-        let currentMonthStart = startOfMonth(for: currentDate)
-        let todayMonthStart   = startOfMonth(for: now)
-        return currentMonthStart < todayMonthStart
-    }
-    
+
     // MARK: - Private
     
     private func startOfMonth(for date: Date) -> Date {

--- a/Moa/Moa/Features/Home/History/Calendar/Components/Calendar/CalendarDayIndicatorView.swift
+++ b/Moa/Moa/Features/Home/History/Calendar/Components/Calendar/CalendarDayIndicatorView.swift
@@ -11,10 +11,10 @@ import SnapKit
 final class CalendarDayIndicatorView: UIView {
     
     private let dotView: UIView = {
-        let v = UIView()
-        v.layer.cornerRadius = 3
-        v.isHidden = true
-        return v
+        let view = UIView()
+        view.layer.cornerRadius = 3
+        view.isHidden = true
+        return view
     }()
     
     private let labelStack: UIStackView = {

--- a/Moa/Moa/Features/Home/History/Calendar/Components/Calendar/CalendarNavigationBar.swift
+++ b/Moa/Moa/Features/Home/History/Calendar/Components/Calendar/CalendarNavigationBar.swift
@@ -126,13 +126,6 @@ final class CalendarNavigationBar: UIView {
         monthLabel.setText(title)
     }
     
-    func setNextEnabled(_ enabled: Bool) {
-        nextButton.isEnabled = enabled
-        nextButton.tintColor = enabled
-            ? AppColor.IconAndText.highEmphasis
-            : AppColor.IconAndText.disabled
-    }
-    
     // MARK: - Actions
     
     @objc private func tappedPrev() { delegate?.navigationBarDidTapPrev() }

--- a/Moa/Moa/Features/Home/History/Calendar/Components/Calendar/CalendarView.swift
+++ b/Moa/Moa/Features/Home/History/Calendar/Components/Calendar/CalendarView.swift
@@ -103,7 +103,6 @@ final class CalendarView: UIView {
     
     private func reloadAll() {
         navBar.setTitle(dataSource.monthTitle(for: dataSource.currentDate))
-        navBar.setNextEnabled(dataSource.canMoveToNextMonth())
         reloadGrid()
     }
     
@@ -130,7 +129,6 @@ final class CalendarView: UIView {
     
     @objc private func handleSwipe(_ gesture: UISwipeGestureRecognizer) {
         if gesture.direction == .left {
-            guard dataSource.canMoveToNextMonth() else { return }
             dataSource.moveToNextMonth()
             slide(.left)
         } else {

--- a/Moa/Moa/Features/Home/Work/WorkMain/Components/WorkMainSummaryView.swift
+++ b/Moa/Moa/Features/Home/Work/WorkMain/Components/WorkMainSummaryView.swift
@@ -49,9 +49,15 @@ final class WorkMainSummaryView: UIView {
         showsChevron: false
     )
 
+    /// 공휴일(NONE): "근무 예정 없음" 고정, 단일 행, chevron X, 탭 불가
+    private lazy var holidayRowView = KeyValueRowView(
+        type: .customRow(key: "근무 시간", value: "근무 예정 없음"),
+        showsChevron: false
+    )
+
     // MARK: - State
 
-    private enum LayoutVariant { case twoRow, finishedRow, vacationRow }
+    private enum LayoutVariant { case twoRow, finishedRow, vacationRow, holidayRow }
     private var currentVariant: LayoutVariant = .twoRow
 
     // MARK: - Init
@@ -71,7 +77,10 @@ final class WorkMainSummaryView: UIView {
     func configure(status: WorkStatusEntity, data: HomeEntity) {
         switch (data.type, status) {
 
-        case (.none, .finished), (.vacation, .finished):
+        case (.none, _):
+            renderHolidayRow()
+
+        case (.vacation, .finished):
             renderVacationRow(dailyPay: data.dailyPay)
 
         // 최종완료 — 근무일: chevron O, 탭 불가
@@ -84,7 +93,7 @@ final class WorkMainSummaryView: UIView {
                 tappable: false
             )
 
-        case (.none, _), (.vacation, _):
+        case (.vacation, _):
             renderVacationRow(dailyPay: data.dailyPay)
 
         default:
@@ -104,7 +113,9 @@ final class WorkMainSummaryView: UIView {
         containerView.backgroundColor = AppColor.Container.primary.withAlphaComponent(0.6)
 
         switch data.type {
-        case .none, .vacation:
+        case .none:
+            renderHolidayRow()
+        case .vacation:
             renderVacationRow(dailyPay: data.dailyPay)
         case .work:
             let clockInStr  = data.clockInTime?.displayString  ?? "--:--"
@@ -154,6 +165,19 @@ final class WorkMainSummaryView: UIView {
         applyBottomRowConstraints(bottomRow: finishedTimeRowView)
     }
 
+    private func renderHolidayRow() {
+        wageRowView.isHidden         = true
+        dividerView.isHidden         = true
+        timeRowView.isHidden         = true
+        finishedTimeRowView.isHidden = true
+        vacationTimeRowView.isHidden = true
+        holidayRowView.isHidden      = false
+
+        guard currentVariant != .holidayRow else { return }
+        currentVariant = .holidayRow
+        applyOneRowConstraints(row: holidayRowView)
+    }
+
     private func renderVacationRow(dailyPay: Int) {
         wageRowView.isHidden         = false
         dividerView.isHidden         = false
@@ -181,12 +205,16 @@ final class WorkMainSummaryView: UIView {
         containerView.snp.makeConstraints { $0.edges.equalToSuperview() }
         containerView.addSubViews([
             wageRowView, dividerView,
-            timeRowView, finishedTimeRowView, vacationTimeRowView
+            timeRowView, finishedTimeRowView, vacationTimeRowView, holidayRowView
         ])
         applyBottomRowConstraints(bottomRow: timeRowView)
     }
 
     private func applyBottomRowConstraints(bottomRow: UIView) {
+        holidayRowView.snp.remakeConstraints {
+            $0.top.horizontalEdges.equalToSuperview().inset(16)
+            $0.height.equalTo(0)
+        }
         wageRowView.snp.remakeConstraints {
             $0.top.horizontalEdges.equalToSuperview().inset(16)
         }
@@ -201,6 +229,31 @@ final class WorkMainSummaryView: UIView {
                 $0.horizontalEdges.equalToSuperview().inset(16)
                 if row === bottomRow { $0.bottom.equalToSuperview().inset(16) }
             }
+        }
+    }
+
+    // MARK: - One Row Layout (공휴일 전용)
+
+    private func applyOneRowConstraints(row: UIView) {
+        // hidden 뷰들: 높이 0 고정 → 내부 subview 제약과 충돌 없이 레이아웃에서 배제
+        wageRowView.snp.remakeConstraints {
+            $0.top.horizontalEdges.equalToSuperview().inset(16)
+            $0.height.equalTo(0)
+        }
+        dividerView.snp.remakeConstraints {
+            $0.top.equalTo(wageRowView.snp.bottom)
+            $0.horizontalEdges.equalToSuperview()
+            $0.height.equalTo(0)
+        }
+        [timeRowView, finishedTimeRowView, vacationTimeRowView].forEach {
+            $0.snp.remakeConstraints {
+                $0.top.equalTo(dividerView.snp.bottom)
+                $0.horizontalEdges.equalToSuperview().inset(16)
+                $0.height.equalTo(0)
+            }
+        }
+        row.snp.remakeConstraints {
+            $0.edges.equalToSuperview().inset(16)
         }
     }
 }

--- a/Moa/Moa/Presentation/Components/DatePicker/DatePickerCalendarView.swift
+++ b/Moa/Moa/Presentation/Components/DatePicker/DatePickerCalendarView.swift
@@ -91,7 +91,6 @@ final class DatePickerCalendarView: UIView {
 
     private func reloadAll() {
         navBar.setTitle(dataSource.monthTitle(for: dataSource.currentDate))
-        navBar.setNextEnabled(dataSource.canMoveToNextMonth())
         reloadGrid()
     }
 
@@ -104,7 +103,6 @@ final class DatePickerCalendarView: UIView {
 
     @objc private func handleSwipe(_ gesture: UISwipeGestureRecognizer) {
         if gesture.direction == .left {
-            guard dataSource.canMoveToNextMonth() else { return }
             dataSource.moveToNextMonth()
             slide(.left)
         } else {

--- a/Moa/Moa/Presentation/Loading/MoaLoadingView.swift
+++ b/Moa/Moa/Presentation/Loading/MoaLoadingView.swift
@@ -47,7 +47,7 @@ final class MoaLoadingView: UIView {
         
         lottieView.snp.makeConstraints {
             $0.center.equalToSuperview()
-            $0.width.height.equalTo(160)
+            $0.width.height.equalTo(52)
         }
     }
     


### PR DESCRIPTION
### 📌 Summary
<!-- 이 PR에서 무엇을 해결했는지 간단히 설명해주세요 -->

- 로딩 인디케이터 수정 및 공휴일 처리

---

### 🛠️ Changes
<!-- 주요 변경 사항을 bullet point로 작성해주세요 -->

- 로딩 인디케이터 수정
- 메인 홈 공휴일 처리
  - 기존에는 공휴일(WorkType.none)을 휴가와 동일한 레이아웃(renderVacationRow)으로 처리.
  - 공휴일 전용 단일 행 UI가 필요해 분리했으며, 레이아웃 전환 시 발생하던 제약 충돌도 함께 수정
- 캘린더 다음달 조정할 수 있도록 변경

---


### 📸 Screenshots / GIF (선택)

| 로딩 | 공휴일 |
|:--:|:--:|
|<img width="1170" height="2532" alt="Simulator Screenshot - iPhone 16e - 2026-03-17 at 23 00 25" src="https://github.com/user-attachments/assets/d260568c-dcae-408c-b1fb-8ba24cf651d3" />|<img width="1170" height="2532" alt="Simulator Screenshot - iPhone 16e - 2026-03-17 at 23 28 26" src="https://github.com/user-attachments/assets/77959270-97a9-4bab-8f44-5eb299f1674d" />|


